### PR TITLE
Allow externally-defined data_sources.json, and allow empty password.

### DIFF
--- a/datasource/bases/BaseHub.py
+++ b/datasource/bases/BaseHub.py
@@ -370,7 +370,14 @@ if not BaseHub.dataSources:
       procsPath = os.path.dirname(__file__).replace('bases', BaseHub.defaultProcDir)
       os.path.walk(procsPath, BaseHub.loadBuiltinProcs, {})
 
-      testDataSourcePath = os.path.dirname(__file__).replace('bases', BaseHub.defaultDataSourceFile)
+      testDataSourcePath = os.environ.get(
+         "DATASOURCES",
+         os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            BaseHub.defaultDataSourceFile
+            )
+         )
+
       BaseHub.getSources(testDataSourcePath, True)
 
       #####

--- a/datasource/bases/RDBSHub.py
+++ b/datasource/bases/RDBSHub.py
@@ -67,7 +67,6 @@ class RDBSHub(BaseHub):
             wrapped function ref 
       """
       def wrapper(self, **kwargs):
-
          self.setExecuteRules(kwargs)
          self.getExecuteData(self.dataSource, kwargs)
          return func(self, **kwargs)
@@ -139,9 +138,9 @@ class RDBSHub(BaseHub):
                          req=set(['hub', 'master_host']),
                          #optional keys but if present have additional key requirements
                          databases=set(['name', 'procs']),
-                         master_host=set(['host', 'user', 'passwd']),
-                         read_host=set(['host', 'user', 'passwd']),
-                         dev_host=set(['host', 'user', 'passwd']) )
+                         master_host=set(['host', 'user']),
+                         read_host=set(['host', 'user']),
+                         dev_host=set(['host', 'user']) )
 
       ###
       #List of SQL tokens that must follow a WHERE statement

--- a/datasource/hubs/MySQL.py
+++ b/datasource/hubs/MySQL.py
@@ -297,13 +297,13 @@ class MySQL(RDBSHub):
          if db:
             self.__connection[hostType]['con_obj'] = MySQLdb.connect( host=self.conf[hostType]['host'],
                                                                       user=self.conf[hostType]['user'],
-                                                                      passwd=self.conf[hostType]['passwd'],
+                                                                      passwd=self.conf[hostType].get('passwd', ''),
                                                                       cursorclass=MySQLdb.cursors.DictCursor,
                                                                       db=db)
          else:
             self.__connection[hostType]['con_obj'] = MySQLdb.connect( host=self.conf[hostType]['host'],
                                                                       user=self.conf[hostType]['user'],
-                                                                      passwd=self.conf[hostType]['passwd'],
+                                                                      passwd=self.conf[hostType].get('passwd', ''),
                                                                       cursorclass = MySQLdb.cursors.DictCursor)
 
          self.__connection[hostType]['cursor'] = self.__connection[hostType]['con_obj'].cursor()


### PR DESCRIPTION
These were the minimal changes necessary to allow me to run the datasource tests. This pull request allows the user to configure their data sources JSON file by setting a `DATASOURCES` environment variable. There'd be a couple other ways to do this, but this was the simplest for now and is consistent with datazilla, which also handles config via env vars.

I also made the "passwd" key optional, since locally my user can connect to MySQL without a password.
