### PR TITLE
Better dependency handling in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,27 @@
 import os, stat
-from distutils.core import setup
-
+kwargs = {}
 try:
-   import MySQLdb
+    from setuptools import setup
+    kwargs["install_requires"] = ["MySQL-python"]
 except ImportError:
-   raise Exception('datasource requires the python module MySQLdb (http://sourceforge.net/projects/mysql-python/')
+    from distutils.core import setup
 
 def read(fname):
    return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
-#Set datas_sources.json to be readable by everyone
-dirName = os.path.dirname(__file__)
-fileName = '.' + dirName + '/datasource/data_sources.json'
-os.chmod(fileName, stat.S_IREAD|stat.S_IWRITE|stat.S_IRGRP|stat.S_IWGRP|stat.S_IROTH)
-
-setup(name='datasource',
-      version='0.5',
-      description='Data Source Encapsulation',
-      license='MPL',
-      keywords = "data SQL MySQL", 
-      author='Jonathan Eads (Jeads)',
-      packages=['datasource', 'datasource.bases', 'datasource.hubs', 'datasource.t'],
-      long_description=read('README'),
-      package_data={'datasource':['procs/mysql_procs/*.json',
+setup(
+    name='datasource',
+    version='0.5',
+    description='Data Source Encapsulation',
+    license='MPL',
+    keywords = "data SQL MySQL", 
+    author='Jonathan Eads (Jeads)',
+    packages=['datasource', 'datasource.bases', 'datasource.hubs', 'datasource.t'],
+    long_description=read('README'),
+    package_data={'datasource':['procs/mysql_procs/*.json',
                                   't/*.txt',
                                   '*.json',
                                   '*.txt',
-                                  'README'] }
-                                  
-      )
+                                  'README'] },
+    **kwargs
+    )


### PR DESCRIPTION
The current import-test for MySQLdb in setup.py is not good dependency-handling practice; if dependencies for some project that uses datasource are being installed via something like a pip requirements file, it's quite likely that MySQLdb and datasource might be installed in the same pip run, and MySQLdb may not be importable yet when datasource's setup.py is first executed. Instead, setuptools' install_requires should be used to list dependencies, which will also allow installers like easy_install and pip to automatically download and install dependencies if necessary. (I've used an import fallback to only use setuptools features if setuptools is actually available; it usually is).

I also removed the permissions-flipping code for data_sources.json, as that's a pretty unusual and unexpected thing to do in a setup.py and I wasn't sure why it would be needed; that code also prevented datasource from being installed via pip because it made unwarranted assumptions about the current working directory being the same directory setup.py is in.

Let me know if I missed something critical!
