### PR TITLE
update connections to default to charset utf8

### DIFF
--- a/datasource/hubs/MySQL.py
+++ b/datasource/hubs/MySQL.py
@@ -69,12 +69,14 @@ class MySQL(SQLHub):
                 self.connection[host_type]['con_obj'] = MySQLdb.connect( host=self.conf[host_type]['host'],
                                                                           user=self.conf[host_type]['user'],
                                                                           passwd=self.conf[host_type].get('passwd', ''),
+                                                                          charset="utf8",
                                                                           cursorclass=MySQLdb.cursors.DictCursor,
                                                                           db=db)
             else:
                 self.connection[host_type]['con_obj'] = MySQLdb.connect( host=self.conf[host_type]['host'],
                                                                           user=self.conf[host_type]['user'],
                                                                           passwd=self.conf[host_type].get('passwd', ''),
+                                                                          charset="utf8",
                                                                           cursorclass = MySQLdb.cursors.DictCursor)
 
             self.connection[host_type]['con_obj'].autocommit(False)


### PR DESCRIPTION
This is to fix errors where some extended characters don't fall into the default charset for mysql.
