### PR TITLE
Reconnect of select_db fails due to an OperationalError

### DIFF
--- a/datasource/hubs/MySQL.py
+++ b/datasource/hubs/MySQL.py
@@ -52,7 +52,13 @@ class MySQL(SQLHub):
             self.try_to_connect(host_type, db)
 
         if db and db != self.connection[host_type]['db']:
-            self.connection[host_type]['con_obj'].select_db(db)
+            try:
+                self.connection[host_type]['con_obj'].select_db(db)
+            except OperationalError:
+                ##Connection is corrupt, reconnect.
+                ##Meant to deal with OperationalError 2006
+                ##MySQL server has gone away errors with Django 1.6
+                self.connect(host_type, db)
             self.connection[host_type]['db'] = db
     """
     Private Methods


### PR DESCRIPTION
Bughunter has been getting intermittent OperationalError 2006's since about Django 1.5/1.6 when sending signals from one panel to another. Retrying usually succeeds.  Looking at the network traffic it seems to be isolated to a failure in select_db. I've been testing this patch for the last couple of days and it appears to have resolved the problem.
