### PR TITLE
Add a datasource config flag for making host_type mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Ex: excerpt from data_source.json file use by the unit tests in /datasource/t::
                                      "user":"jeads",
                                      "passwd":"pwd" },
 
+                      # Optional. If set, host_type is mandatory.
+                      "require_host_type": false,
+
                       ##Not required##
                       "default_db": "test",
 
@@ -391,6 +394,10 @@ This is an excerpt of a datasource file that is used by the unit tests.
                                     "user":"jeads",
                                     "passwd":"pwd" },
 
+
+                     # Optional. If set, host_type is mandatory.
+                     "require_host_type": false,
+
                      ##Not required##
                      "default_db": "test",
 
@@ -423,6 +430,8 @@ Option definitions
 
 * ``dev_host`` - Optional, use it if you have a development only host and want to be able
          to specify connecting to it in the RDBSHub.
+
+* ``require_host_type`` - Optional, use it if you want to enforce that a host_type is set.
 
 * ``default_db`` - Optional, specifies a default database name to execute queries
            against.

--- a/datasource/bases/RDBSHub.py
+++ b/datasource/bases/RDBSHub.py
@@ -359,6 +359,8 @@ class RDBSHub(BaseHub):
             ####
             host_type = kwargs['host_type']
         elif not host_type:
+            if self.conf.get('require_host_type', False):
+                raise RDBSHubExecuteError("host_type is required, but none was specified")
             ##No host type in proc file or in kwargs, set default
             host_type = self.default_host_type
 

--- a/datasource/data_sources.json
+++ b/datasource/data_sources.json
@@ -16,6 +16,9 @@
                                  "user":"username",
                                  "passwd":"passwd" },
 
+                  # Optional. If set, host_type is mandatory.
+                  "require_host_type": false,
+
                   ##Not required, if set execute uses this db as a default##
                   "default_db": "test",
 


### PR DESCRIPTION
If 'require_host_type' is present in the datasource config and truthy, a RDBSHubExecuteError exception will be raised if host_type is not defined, rather than the normal fall-back to a type of 'master_host'.

This makes it easier to catch cases where 'host_type' was omitted from the procs file, and queries would otherwise have run against the master host unnecessarily.

Fixes #21.