### PR TITLE
Update setup.py README references after ed4a02ac8d to fix pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,11 @@ setup(
     keywords = "data SQL MySQL", 
     author='Jonathan Eads (Jeads)',
     packages=['datasource', 'datasource.bases', 'datasource.hubs', 'datasource.t'],
-    long_description=read('README'),
+    long_description=read('README.md'),
     package_data={'datasource':['procs/mysql_procs/*.json',
                                   't/*.txt',
                                   '*.json',
                                   '*.txt',
-                                  'README'] },
+                                  'README.md'] },
     **kwargs
     )


### PR DESCRIPTION
#18 renamed the readme, but the old file was still referenced, causing failures during pip install.