### PR TITLE
Bump the version to 0.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name='datasource',
-    version='0.5',
+    version='0.6',
     description='Data Source Encapsulation',
     license='MPL',
     keywords = "data SQL MySQL", 


### PR DESCRIPTION
@jeads the version hasn't changed since the initial commit in the repo. Bumping now, since it will help us track which nodes have the updated lib - given updating is a manual task on stage/prod and we've had issues with consistency in the past.