### PR TITLE
Bug 1182485 - Strip leading/trailing whitespace from datasource files

### DIFF
--- a/datasource/bases/BaseHub.py
+++ b/datasource/bases/BaseHub.py
@@ -61,13 +61,8 @@ class BaseHub:
 
            Returns: None
         """
-        source_file_obj = open(source_file_path)
-
-        source_file = None
-        try:
-            source_file = source_file_obj.read()
-        finally:
-            source_file_obj.close()
+        with open(source_file_path) as f:
+            source_file = '\n'.join(line.strip() for line in f)
 
         data_sources = BaseHub.deserialize_json(source_file)
 


### PR DESCRIPTION
So as to make the queries more readable in logs / avoid bloating the binlogs.

This turns:

```json
    "inserts":{
        "create_job_data":{
            "sql":"INSERT INTO `job` (
                `job_guid`,
                `signature`,
                `job_coalesced_to_guid`,
                `result_set_id`,
...
```

Into:

```json
"inserts":{
"create_job_data":{
"sql":"INSERT INTO `job` (
`job_guid`,
`signature`,
`job_coalesced_to_guid`,
`result_set_id`,
...
```

strip_python_comments() will then remove the newlines later, but that cannot be done at file read, otherwise it's much harder to remove the file comments.

