### PR TITLE
Bug 1182994 - Fix handling of limit and offset parameters

### DIFF
--- a/datasource/bases/RDBSHub.py
+++ b/datasource/bases/RDBSHub.py
@@ -331,7 +331,7 @@ class RDBSHub(BaseHub):
         if 'limit' in kwargs:
             sql = "%s LIMIT %s" % (sql, str(kwargs['limit']))
         if 'offset' in kwargs:
-            sql = "%s OFFSET %s" % (sql, str(kwargs['limit']))
+            sql = "%s OFFSET %s" % (sql, str(kwargs['offset']))
 
         # Compute number of execute sets if user requests chunking
         # ORDER IS CRITICAL HERE: sql must be passed to chunk stuff

--- a/datasource/bases/RDBSHub.py
+++ b/datasource/bases/RDBSHub.py
@@ -329,9 +329,9 @@ class RDBSHub(BaseHub):
 
         # Set limits and offset
         if 'limit' in kwargs:
-            sql = "%s LIMIT %s" % (sql, str(kwargs['limit']))
+            sql = "%s LIMIT %s" % (sql, int(kwargs['limit']))
         if 'offset' in kwargs:
-            sql = "%s OFFSET %s" % (sql, str(kwargs['offset']))
+            sql = "%s OFFSET %s" % (sql, int(kwargs['offset']))
 
         # Compute number of execute sets if user requests chunking
         # ORDER IS CRITICAL HERE: sql must be passed to chunk stuff


### PR DESCRIPTION
* Correctly use the 'offset' param instead of 'limit', since the wrong parameter was being substituted.
* Cast the limit and offset parameters to int, to prevent SQL injection if those parameters were not sanitised in the app. Note: This intentionally removes the ability to pass a limit string of say "100,200" - since IMO the offset parameter makes this redundant (and now the offset param is fixed we can actually use it).