### PR TITLE
Bug 1182485 - Strip leading/trailing whitespace from proc files

### DIFF
--- a/datasource/bases/BaseHub.py
+++ b/datasource/bases/BaseHub.py
@@ -203,11 +203,8 @@ class BaseHub:
             for file in BaseHub.data_sources[data_source]['procs']:
 
                 # Load file
-                proc_file_obj = open(file)
-                try:
-                    proc_file = proc_file_obj.read()
-                finally:
-                    proc_file_obj.close()
+                with open(file) as f:
+                    proc_file = '\n'.join(line.strip() for line in f)
 
                 # Use file name as key
                 head, tail = os.path.split(file)


### PR DESCRIPTION
The last commit trying to achieve the same only modified the codepath used by tests, this applies the same trick against the common codepath too. Tested locally by dumping the generated SQL prior to the MySQL Python connector `.execute()` call.