### PR TITLE
Add support for a return_type of `rowcount`

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,8 +601,8 @@ This interface looks like this:
                                 of dict* or set*
             -R RETURN_TYPE, --return_type=RETURN_TYPE
                                 Possible values are dict, dict_json, tuple, tuple_json,
-                                table, table_json, set, and set_json.  Defaults to tuple.
-        
+                                table, table_json, set, set_json and rowcount.  Defaults to tuple.
+
           Debug Options:
             -s, --debug_show    Show SQL and other info about the query including
                                 execution time.
@@ -766,7 +766,7 @@ Ex: Using the chunking options
 ####Output related keys
 
 ``return_type`` - Possible values are ``iter``, ``dict``, ``dict_json``, ``tuple``, ``tuple_json``,
-             ``table``, ``table_json``, ``set``, ``set_json``, and ``callback``.  Return type
+             ``table``, ``table_json``, ``set``, ``set_json``, ``callback`` and ``rowcount``.  Return type
              selections of ``dict`` and ``callback`` require additional key/value pairs.
              Defaults to ``tuple``.
 
@@ -825,6 +825,7 @@ Ex: Using the chunking options
       key_column_value3:None,
       key_column_value4:None, etc...}
 
+``rowcount`` - The number of rows fetched or affected.
 
 ``callback`` - When a callback is specified a function reference can be provided to
          be used as a callback.  The callback will be called for every row

--- a/datasource/DataHub.py
+++ b/datasource/DataHub.py
@@ -242,7 +242,7 @@ if __name__ == '__main__':
                   ('limit', '-l', 'A limit to append to the sql as LIMIT integer.'),
                   ('offset', '-o', 'An offset to append to the sql as OFFSET integer.'),
                   ('key_column', '-k', 'table.column to use as a key_column for return_types of dict* or set*'),
-                  ('return_type', '-R', 'Possible values are dict, dict_json, tuple, tuple_json, set, table, table_json, and set_json.  Defaults to list'))
+                  ('return_type', '-R', 'Possible values are dict, dict_json, tuple, tuple_json, set, table, table_json, set_json and rowcount.  Defaults to list'))
 
     debug_group = (('debug_show', '-s', 'Show SQL and other info about the query including execution time.'),
                    ('debug_noex', '-n', 'Show SQL and other info about the query without executing it.'))

--- a/datasource/bases/RDBSHub.py
+++ b/datasource/bases/RDBSHub.py
@@ -93,6 +93,7 @@ class RDBSHub(BaseHub):
                                    'set_json': None,
                                    'table': None,
                                    'table_json': None,
+                                   'rowcount': None,
                                    'callback': None}
 
         # Dictionary of required keys for RDBS datasources

--- a/datasource/bases/SQLHub.py
+++ b/datasource/bases/SQLHub.py
@@ -45,6 +45,7 @@ class SQLHub(RDBSHub):
         self.valid_return_types['table'] = self.get_table
         self.valid_return_types['table_json'] = self.get_table_json
         self.valid_return_types['set_json'] = self.get_set_json
+        self.valid_return_types['rowcount'] = self.get_rowcount
         self.valid_return_types['callback'] = self.get_callback
 
         """
@@ -216,6 +217,9 @@ class SQLHub(RDBSHub):
     def get_table_json(self, cursor, kwargs):
         data_struct = self.get_table(cursor, kwargs)
         return json.dumps(data_struct)
+
+    def get_rowcount(self, cursor, kwargs):
+        return cursor.rowcount
 
     def get_callback(self, cursor, kwargs):
         callback = kwargs['callback']

--- a/datasource/procs/mysql_procs/test.json
+++ b/datasource/procs/mysql_procs/test.json
@@ -65,6 +65,13 @@
        "host_type":"master_host"
    },
 
+   "update_test_data_category":{
+       "sql":"UPDATE `test`.`DATA_SOURCES_TEST_DATA`
+              SET `category` = 'foo'
+              WHERE `id` = ?",
+       "host_type":"master_host"
+   },
+
    "create_table":{
       "sql":"CREATE TABLE IF NOT EXISTS `test`.`DATA_SOURCES_TEST_DATA` (
                `id` int(5) PRIMARY KEY NOT NULL AUTO_INCREMENT,

--- a/datasource/t/TestMySQLHub.py
+++ b/datasource/t/TestMySQLHub.py
@@ -66,6 +66,7 @@ class TestMySQLHub(unittest.TestCase):
                  'test_set_json_return_type',
                  'test_table_return_type',
                  'test_table_json_return_type',
+                 'test_rowcount_return_type',
                  'test_callback_return_type',
                  'test_chunking',
                  'test_chunking_with_min',
@@ -393,6 +394,27 @@ class TestMySQLHub(unittest.TestCase):
 
         msg = 'The items in data set, %i, do not match the row count %i.' % (rowcount, self.limit)
         self.assertEqual(rowcount, self.limit, msg=msg)
+
+    def test_rowcount_return_type(self):
+        rowcount_valid_update = self.dh.execute(
+            db=self.db,
+            proc="test.update_test_data_category",
+            placeholders=[1],
+            return_type='rowcount',
+        )
+        exp_rowcount_valid_update = 1
+        msg = 'number of rows updated, %i, does not match %i.' % (rowcount_valid_update, exp_rowcount_valid_update)
+        self.assertEqual(rowcount_valid_update, exp_rowcount_valid_update, msg=msg)
+
+        rowcount_invalid_update = self.dh.execute(
+            db=self.db,
+            proc="test.update_test_data_category",
+            placeholders=[99999],
+            return_type='rowcount',
+        )
+        exp_rowcount_invalid_update = 0
+        msg = 'number of rows updated, %i, does not match %i.' % (rowcount_invalid_update, exp_rowcount_invalid_update)
+        self.assertEqual(rowcount_invalid_update, exp_rowcount_invalid_update, msg=msg)
 
     def test_callback_return_type(self):
         self.dh.execute(


### PR DESCRIPTION
Which returns the value from `cursor.rowcount`. This makes it possible to determine how many rows were affected by an UPDATE for example.

This feature is going to be used to resolve https://bugzilla.mozilla.org/show_bug.cgi?id=1226565